### PR TITLE
Fixes #30

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,29 @@
+language: python
+python: "3.6"
 addons:
     apt:
         packages:
             - cmake
             - gfortran
 
-before_install:
-    # Need to install Python3.5 for running the tests.
-    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda update -q conda
-    # Useful for debugging any issues with conda
-    - conda info -a
+# before_install:
+#     # Need to install Python3.5 for running the tests.
+#     - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+#     - bash miniconda.sh -b -p $HOME/miniconda
+#     - export PATH="$HOME/miniconda/bin:$PATH"
+#     - hash -r
+#     - conda config --set always_yes yes --set changeps1 no
+#     - conda update -q conda
+#     # Useful for debugging any issues with conda
+#     - conda info -a
 
+# install:
+#     - conda create -q -n testenv --yes pip python=3.6
+#     - source activate testenv
+#     - conda install --yes numpy
 install:
-    - conda create -q -n testenv --yes pip python=3.5
-    - source activate testenv
-    - conda install --yes numpy
+    - pip install --upgrade pip setuptools wheel
+    - pip install numpy 
 
 script:
     - mkdir build tests
@@ -26,5 +31,5 @@ script:
     - cmake ..
     - make
     - cd ../scripts
-    - python3 run_tests.py --cores 2 --haz_bin ../build/HAZ --rtol 0.005
+    - python3 run_tests.py --cores 2 --haz_bin ../build/HAZ --rtol 0.005 Set1 Set2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,21 +6,6 @@ addons:
             - cmake
             - gfortran
 
-# before_install:
-#     # Need to install Python3.5 for running the tests.
-#     - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-#     - bash miniconda.sh -b -p $HOME/miniconda
-#     - export PATH="$HOME/miniconda/bin:$PATH"
-#     - hash -r
-#     - conda config --set always_yes yes --set changeps1 no
-#     - conda update -q conda
-#     # Useful for debugging any issues with conda
-#     - conda info -a
-
-# install:
-#     - conda create -q -n testenv --yes pip python=3.6
-#     - source activate testenv
-#     - conda install --yes numpy
 install:
     - pip install --upgrade pip setuptools wheel
     - pip install numpy 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,3 @@ script:
     - make
     - cd ../scripts
     - python3 run_tests.py --cores 2 --haz_bin ../build/HAZ --rtol 0.005 Set1 Set2
-

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,7 +48,7 @@ with:
                             case directory is empty. (default: False)
       -r RTOL, --rtol RTOL  Relative tolerance used for float comparisons.
                             (default: 0.002)
-      -s ROOT_SRC, --root_src ROOT_SRC
+      -s ROOT_REF, --root_ref ROOT_REF
                             Root path of test cases (default:
                             ../PEER_Verification_Tests/)
       -t ROOT_TEST, --root_test ROOT_TEST
@@ -90,3 +90,44 @@ By default, only the tests with fast calculation time are performed. All
 tests, can be run with the `-a` or `--all_tests` flag, such as:
 
     $> python run_tests.py -a -c 2 -b ../build/HAZ -r 0.005
+
+## Test Duration
+
+During the testing process, the time for running `HAZ` on a given input file is
+reported. If the test output is redirected to a file, the test duration can be
+extracted as follows:
+
+    $> python run_tests.py -a -c 2 -b ../build/HAZ -r 0.005 > test.log
+    $> cat haz_tests.log | sed -En 's/.*: (\S+) (\S+)$/\1\t\2/p' | sort
+
+    Set1/S1Test01           0:00:00.938700
+    Set1/S1Test02           0:00:33.722160
+    Set1/S1Test04           0:00:45.615901
+    Set1/S1Test05           1:15:58.920194
+    Set1/S1Test06           1:18:25.974351
+    Set1/S1Test07           1:18:23.266588
+    Set1/S1Test08a          0:00:33.947122
+    Set1/S1Test08b          0:00:35.287663
+    Set1/S1Test08c          0:00:34.911442
+    Set1/S1Test10           0:00:05.554910
+    Set1/S1Test11           0:00:24.390950
+    Set2/S2Test1            0:02:35.734937
+    Set2/S2Test2a           1:13:19.895491
+    Set2/S2Test2b           1:21:30.252216
+    Set2/S2Test2c           1:19:56.661891
+    Set2/S2Test2d           1:13:25.263971
+    Set2/S2Test3a           0:00:07.209199
+    Set2/S2Test3b           0:00:07.187167
+    Set2/S2Test3c           0:00:10.300279
+    Set2/S2Test3d           0:00:07.637015
+    Set2/S2Test4a           0:00:22.463504
+    Set2/S2Test4b           0:00:29.631422
+    Set2/S2Test5a           0:00:05.331427
+    Set2/S2Test5b           0:00:04.926723
+    Set3/S3Test1a           0:00:01.603328
+    Set3/S3Test1b           0:00:01.516753
+    Set3/S3Test2/Fractiles  0:07:55.357953
+    Set3/S3Test2/Hazard     0:08:17.658489
+
+The calculation time ranges from less than a second to almost to 90 minutes for
+this test computer.

--- a/scripts/io_tools.py
+++ b/scripts/io_tools.py
@@ -1,17 +1,30 @@
+
 import re
+from typing import Callable, Dict, List, Tuple, TypeVar
+
 import numpy as np
 
+T = TypeVar('T', dict, int, float, str)
 
-def fixed_split(line, pairs, keep_tail=False):
+def fixed_split(line: str,
+                pairs: List[Tuple[int, Callable]],
+                keep_tail: bool=False
+                ) -> List[T]:
     """Read a fixed width line of text.
 
-    Args:
-        line (str): text line to parse
-        pairs (list): list of tuples specifying the width and the string parser
-        keep_tail (bool): remove entries without values
+    Parameters
+    ----------
+    line : str
+        text line to parse
+    pairs : list[(int, func)]
+        list of tuples specifying the width and the string parser
+    keep_tail : bool
+        remove entries without values
 
-    Returns:
-        list: values read
+    Returns
+    -------
+    values : list
+        values read
     """
     line = line.rstrip()
 
@@ -27,13 +40,15 @@ def fixed_split(line, pairs, keep_tail=False):
         i += w
 
     if not keep_tail:
-        while values[-1] is None:
+        while values and values[-1] is None:
             values.pop()
 
-    return values
+    return tuple(values)
 
 
-def parse_blocks(lines, pattern):
+def parse_blocks(lines: List[str],
+                 pattern: str
+                 ) -> List[str]:
     """Separate lines into a series of blocks using an identifying pattern.
 
     Parameters
@@ -44,7 +59,8 @@ def parse_blocks(lines, pattern):
         Regex pattern used to identify the blocks.
     Returns
     -------
-    list[str]
+    blocks : list[str]
+        Parsed blocks
     """
     starts = [i for i, l in enumerate(lines)
               if re.search(pattern, l)]
@@ -53,16 +69,16 @@ def parse_blocks(lines, pattern):
     return blocks
 
 
-def parse_site_line(line):
+def parse_site_line(line: str) -> Dict[str, T]:
     """Parse the site line in out3 and out4 files.
 
     Parameters
     ----------
-    line: str
+    line : str
         Line of text
     Returns
     -------
-    dict
+    site : dict
         Site dictionary containing keys:
             id: int
                 identifier
@@ -80,7 +96,9 @@ def parse_site_line(line):
     return s
 
 
-def pop_lines(lines, count):
+def pop_lines(lines: List[str],
+              count: int
+              ) -> List[str]:
     """Pop a given number of lines from the start of a list.
 
     Parameters
@@ -92,7 +110,7 @@ def pop_lines(lines, count):
 
     Returns
     -------
-    list[str]
+    popped : list[str]
         Lines removed
     """
     popped = []
@@ -101,7 +119,10 @@ def pop_lines(lines, count):
     return popped
 
 
-def pop_until(lines, pattern, include_match=True):
+def pop_until(lines: List[str],
+              pattern: str,
+              include_match: bool=True
+              ) -> List[str]:
     """Pop lines from the start of a list until a regex pattern is found.
 
     Parameters
@@ -115,7 +136,7 @@ def pop_until(lines, pattern, include_match=True):
 
     Returns
     -------
-    list[str]
+    popped : list[str]
         Lines removed
     """
     popped = []
@@ -128,7 +149,7 @@ def pop_until(lines, pattern, include_match=True):
     return popped
 
 
-def read_out3(fname):
+def read_out3(fname: str) -> Dict[str, T]:
     """Read a HAZ out3 formatted text file.
 
     Parameters
@@ -138,7 +159,8 @@ def read_out3(fname):
 
     Returns
     -------
-    dict
+    site : dict
+        Dictionary containing site information
     """
     assert fname.endswith('.out3')
 
@@ -261,7 +283,7 @@ def test_read_out3():
             model[key], expected, err_msg='Key: %s' % key)
 
 
-def read_out4(fname):
+def read_out4(fname: str) -> Dict[str, T]:
     """Read a HAZ out4 formatted text file.
 
     Parameters
@@ -271,7 +293,8 @@ def read_out4(fname):
 
     Returns
     -------
-    dict
+    site : dict
+        Dictionary containing site information
     """
     assert fname.endswith('.out4')
 
@@ -364,3 +387,9 @@ def test_read_out4():
         for key, expected in zip(keys, test_bin):
             actual = site['bins'][idx][key]
             np.testing.assert_allclose(actual, expected)
+
+
+
+# def load_fractiles(fname):
+# def read_out4(fname: str) -> Dict[str, T]:
+

--- a/scripts/io_tools.py
+++ b/scripts/io_tools.py
@@ -389,7 +389,47 @@ def test_read_out4():
             np.testing.assert_allclose(actual, expected)
 
 
+def read_fractiles(fname):
+    with open(fname) as fp:
+        lines = list(fp)
 
-# def load_fractiles(fname):
-# def read_out4(fname: str) -> Dict[str, T]:
+    period = float(lines.pop(0)[:12])
 
+    intensity = np.array(
+        fixed_split(lines.pop(0), 18 * [(12, float)]))
+
+    block = pop_until(lines, r'^\s+$', include_match=False)
+
+    values = [fixed_split(b, [(7, float)] + 17 * [(12, float)])
+              for b in block]
+
+    fractiles = np.array([v[0] for v in values])
+    hazard = np.array([v[1:] for v in values])
+
+    mean = np.array(
+        fixed_split(lines.pop(0)[7:], 17 * [(12, float)])
+    )
+    pop_until(lines, r'^-+$', include_match=False)
+    pop_lines(lines, 4)
+    hazard = float(lines.pop(0)[35:])
+    pop_lines(lines, 2)
+
+    summary = np.array(
+        [fixed_split(l, [(11, float)] + 5 * [(12, float)])
+         for l in lines],
+        dtype=np.dtype([
+            ('period', '<f8'),
+            ('5th', '<f8'),
+            ('10th', '<f8'),
+            ('50th', '<f8'),
+            ('90th', '<f8'),
+            ('95th', '<f8'),
+        ]),
+    )
+
+    # FIXME
+
+def test_read_fractiles():
+    fname = '../PEER_Verification_Tests/' \
+        'Set3/S3Test2/Fractiles/Output/Fract_Set3Test2_Site1.out'
+    # FIXME

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -178,6 +178,7 @@ def iter_cases(path_src: str,
             path = pathlib.Path(root).parent
             # Check cases with long runtimes
             if not all_cases and any(path.match(lc) for lc in long_cases):
+                print('Skipping:', path)
                 continue
 
             yield path

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+"""Functions to run tests on reference cases."""
+
 import argparse
 import datetime
 import functools
-import glob
 import multiprocessing
 import pathlib
 import os
@@ -18,7 +19,6 @@ from typing import List
 
 import numpy as np
 
-import checksum
 import io_tools
 
 
@@ -32,9 +32,11 @@ def check_dictionary(actual, expected, rtol: float, atol: float):
     expected: dict
         Dictionary of expected (reference) values to be tested against.
     rtol: float
-        Relative tolerance of the float comparisons, see :func:`numpy.allclose`.
+        Relative tolerance of the float comparisons, see
+        :func:`numpy.allclose`.
     atol: float
-        Absolute tolerance of the float comparisons, see :func:`numpy.allclose`.
+        Absolute tolerance of the float comparisons, see
+        :func:`numpy.allclose`.
     Returns
     -------
     dict
@@ -68,9 +70,11 @@ def check_value(actual, expected, rtol, atol):
     expected: : str, int, float, dict, list, tuple
         Value to test against (reference). Type should match the acutal type.
     rtol: float
-        Relative tolerance of the float comparisons, see :func:`numpy.allclose`.
+        Relative tolerance of the float comparisons, see
+        :func:`numpy.allclose`.
     atol: float
-        Absolute tolerance of the float comparisons, see :func:`numpy.allclose`.
+        Absolute tolerance of the float comparisons, see
+        :func:`numpy.allclose`.
     Returns
     -------
     None or tuple(actual, expected):
@@ -141,12 +145,9 @@ def print_errors(name, errors):
         raise NotImplementedError
 
 
-def iter_cases(path_src: str,
-               patterns: List[str],
-               all_cases: bool=False
-               ) -> pathlib.PurePath:
-    """Iterate over test cases.
-    """
+def iter_cases(path_src: str, patterns: List[str],
+               all_cases: bool=False) -> pathlib.PurePath:
+    """Iterate over test cases."""
     # Excluded filenames
     excluded = [
         # FIXME: Currently calculation of fractiles is not supported
@@ -161,6 +162,11 @@ def iter_cases(path_src: str,
         'Set2/S2Test2b',
         'Set2/S2Test2c',
         'Set2/S2Test2d',
+        'Set3/S3Test2',
+        'Set3/S3Test2/Fractiles',
+        'Set3/S3Test2/Hazard',
+        'Set3/S3Test3/Approach b1',
+        'Set3/S3Test3/Approach b2',
     ]
 
     pattern_run = r'^Run_\S+\.txt$'
@@ -200,11 +206,11 @@ def run_haz(path: pathlib.PurePath, haz_bin: str):
 
 
 def test_path(path_ref: pathlib.PurePath,
-             force: bool=True,
-             haz_bin: str='HAZ',
-             root_ref: str='',
-             root_test: str='',
-             rtol: float=1E-3) -> bool:
+              force: bool=True,
+              haz_bin: str='HAZ',
+              root_ref: str='',
+              root_test: str='',
+              rtol: float=1E-3) -> bool:
 
     print(path_ref)
     path_test = pathlib.Path(root_test, path_ref.relative_to(root_ref))
@@ -249,9 +255,10 @@ def test_path(path_ref: pathlib.PurePath,
         errors = check_value(actual, expected, rtol, atol=1e-08)
         ok &= (not errors)
         if errors:
-            print('Errors in:', name)
-            print_errors('%s: ' % fname, errors)
+            print('Errors in: %s' % fpath_test)
+            print_errors('%s: ' % fpath_test, errors)
     return ok
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
@@ -259,17 +266,17 @@ if __name__ == '__main__':
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument('-a', '--all_cases', action='store_true',
-                        help='Perform all test cases, ' +
-                             'which might take many hours.')
+                        help='Perform all test cases, '
+                        'which might take many hours.')
     parser.add_argument('-b', '--haz_bin', type=str,
                         default='../build/HAZ.exe',
-                        help='Name of HAZ binary. ' +
-                             'Path is required if not in PATH variable.')
+                        help='Name of HAZ binary. '
+                        'Path is required if not in PATH variable.')
     parser.add_argument('-c', '--cores', type=int, default=1,
                         help='Number of cores to use.')
     parser.add_argument('-f', '--force', action='store_true',
                         help='Force HAZ to rerun; otherwise it only runs if '
-                             'test case directory is empty.')
+                        'test case directory is empty.')
     parser.add_argument('-r', '--rtol', type=float, default=2E-3,
                         help='Relative tolerance used for float comparisons.')
     parser.add_argument('-s', '--root_ref', type=str,
@@ -287,8 +294,8 @@ if __name__ == '__main__':
         ok = True
         for name in iter_cases(args.root_ref, args.patterns, args.all_cases):
             ok &= test_path(name, force=args.force, root_ref=args.root_ref,
-                           root_test=args.root_test, haz_bin=args.haz_bin,
-                           rtol=args.rtol)
+                            root_test=args.root_test, haz_bin=args.haz_bin,
+                            rtol=args.rtol)
     else:
         # Multi-threaded
         processes = min(max(1, args.cores), multiprocessing.cpu_count())

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -2,9 +2,11 @@
 # -*- coding: utf-8 -*-
 
 import argparse
+import datetime
 import functools
 import glob
 import multiprocessing
+import pathlib
 import os
 import re
 import shutil
@@ -12,13 +14,15 @@ import subprocess
 import sys
 import time
 
+from typing import List
+
 import numpy as np
 
 import checksum
 import io_tools
 
 
-def check_dictionary(actual, expected, rtol, atol):
+def check_dictionary(actual, expected, rtol: float, atol: float):
     """Check each value in a dictionary.
 
     Parameters
@@ -137,37 +141,17 @@ def print_errors(name, errors):
         raise NotImplementedError
 
 
-def iter_cases(path, patterns):
-    for root, dirnames, fnames in os.walk(path):
-        for fname in fnames:
-            if not re.match(r'Run_\S+\.txt', fname):
-                continue
-            if patterns and not any(re.search(p, fname) for p in patterns):
-                continue
-            _path = os.path.relpath(
-                os.path.join(root, '..'),
-                path
-            ).replace(os.sep, '/')
-            yield _path
-
-
-def run_haz(path, haz_bin):
-    fname = glob.glob(os.path.join(path, 'Run_*'))[0]
-    print('Running HAZ on:', fname)
-    dirname, basename = os.path.split(fname)
-    haz_bin = os.path.abspath(haz_bin)
-    with open(os.devnull, 'w') as fp:
-        p = subprocess.Popen([haz_bin],
-                             stdout=fp,
-                             stdin=subprocess.PIPE,
-                             cwd=dirname)
-        # Process one file
-        p.communicate(bytes('0\n0\n%s\n' % basename, 'ascii'))
-        p.wait()
-
-
-def test_set(name, all_cases, force=True, haz_bin='HAZ',
-             root_src='', root_test='', rtol=1E-3):
+def iter_cases(path_src: str,
+               patterns: List[str],
+               all_cases: bool=False
+               ) -> pathlib.PurePath:
+    """Iterate over test cases.
+    """
+    # Excluded filenames
+    excluded = [
+        # FIXME: Currently calculation of fractiles is not supported
+        'Run_Fractiles.txt',
+    ]
     # These cases take a couple hours to run
     long_cases = [
         'Set1/S1Test05',
@@ -179,16 +163,51 @@ def test_set(name, all_cases, force=True, haz_bin='HAZ',
         'Set2/S2Test2d',
     ]
 
-    # fixme check this
-    # if not REF_CHECKSUMS[name] == checksum.hash_directory(dirpath):
-    #     logging.critical('Reference case has changed!')
-    #     assert False
-    ok = True
-    path_test = os.path.join(root_test, name)
-    if not os.path.exists(path_test) or force:
-        if name in long_cases and not all_cases:
-            return True
+    pattern_run = r'^Run_\S+\.txt$'
 
+    for root, dirnames, fnames in os.walk(path_src):
+        for fname in fnames:
+            if fname in excluded:
+                continue
+            if not re.match(pattern_run, fname):
+                continue
+
+            if patterns and not any(re.search(p, root) for p in patterns):
+                continue
+
+            path = pathlib.Path(root).parent
+            # Check cases with long runtimes
+            if not all_cases and any(path.match(lc) for lc in long_cases):
+                continue
+
+            yield path
+
+
+def run_haz(path: pathlib.PurePath, haz_bin: str):
+    # Use the first Run_ filename
+    fpath = next(path.glob('Run_*.txt'))
+    print('Running HAZ on:', fpath)
+    haz_bin = os.path.abspath(haz_bin)
+    with open(os.devnull, 'w') as fp:
+        p = subprocess.Popen([haz_bin],
+                             stdout=fp,
+                             stdin=subprocess.PIPE,
+                             cwd=str(fpath.parent))
+        # Process one file
+        p.communicate(bytes('0\n0\n%s\n' % fpath.name, 'ascii'))
+        p.wait()
+
+
+def test_path(path_ref: pathlib.PurePath,
+             force: bool=True,
+             haz_bin: str='HAZ',
+             root_ref: str='',
+             root_test: str='',
+             rtol: float=1E-3) -> bool:
+
+    print(path_ref)
+    path_test = pathlib.Path(root_test, path_ref.relative_to(root_ref))
+    if not path_test.exists() or force:
         try:
             shutil.rmtree(path_test)
             # Wait for my slow computer :-/
@@ -196,23 +215,32 @@ def test_set(name, all_cases, force=True, haz_bin='HAZ',
         except FileNotFoundError:
             pass
 
-        shutil.copytree(os.path.join(root_src, name, 'Input'),
-                        path_test)
+        # Copy files over
+        shutil.copytree(path_ref.joinpath('Input'), path_test)
+        # Run HAZ and track the duration
+        start = datetime.datetime.now()
         run_haz(path_test, haz_bin)
+        time_diff = datetime.datetime.now() - start
 
-    for fname in glob.glob(os.path.join(path_test, '*')):
-        ext = os.path.splitext(fname)[1]
-        fname_expected = os.path.join(root_src, name, 'Output',
-                                      os.path.basename(fname))
-        if not os.path.exists(fname_expected):
+        print(
+            'Calculation time: {} {}'.format(
+                path_ref.relative_to(root_ref), time_diff)
+        )
+
+    ok = True
+    for fpath_test in path_test.iterdir():
+        ext = fpath_test.suffix
+        fpath_ref = path_ref.joinpath('Output', fpath_test.name)
+
+        if not fpath_ref.exists():
             continue
 
         if ext == '.out3':
-            expected = io_tools.read_out3(fname_expected)
-            actual = io_tools.read_out3(fname)
+            expected = io_tools.read_out3(str(fpath_ref))
+            actual = io_tools.read_out3(str(fpath_test))
         elif ext == '.out4':
-            expected = io_tools.read_out4(fname_expected)
-            actual = io_tools.read_out4(fname)
+            expected = io_tools.read_out4(str(fpath_ref))
+            actual = io_tools.read_out4(str(fpath_test))
         else:
             continue
 
@@ -243,7 +271,7 @@ if __name__ == '__main__':
                              'test case directory is empty.')
     parser.add_argument('-r', '--rtol', type=float, default=2E-3,
                         help='Relative tolerance used for float comparisons.')
-    parser.add_argument('-s', '--root_src', type=str,
+    parser.add_argument('-s', '--root_ref', type=str,
                         default='../PEER_Verification_Tests/',
                         help='Root path of test cases')
     parser.add_argument('-t', '--root_test', type=str,
@@ -256,21 +284,21 @@ if __name__ == '__main__':
     if args.cores == 1:
         # Single thread
         ok = True
-        for name in iter_cases(args.root_src, args.patterns):
-            ok &= test_set(name, force=args.force, all_cases=args.all_cases,
-                           root_src=args.root_src, root_test=args.root_test,
-                           haz_bin=args.haz_bin, rtol=args.rtol)
+        for name in iter_cases(args.root_ref, args.patterns, args.all_cases):
+            ok &= test_path(name, force=args.force, root_ref=args.root_ref,
+                           root_test=args.root_test, haz_bin=args.haz_bin,
+                           rtol=args.rtol)
     else:
         # Multi-threaded
         processes = min(max(1, args.cores), multiprocessing.cpu_count())
 
         with multiprocessing.Pool(processes) as pool:
             results = pool.map_async(
-                functools.partial(test_set, force=args.force,
-                                  all_cases=args.all_cases, root_src=args.root_src,
-                                  root_test=args.root_test, haz_bin=args.haz_bin,
-                                  rtol=args.rtol),
-                iter_cases(args.root_src, args.patterns))
+                functools.partial(test_path, force=args.force,
+                                  root_ref=args.root_ref,
+                                  root_test=args.root_test,
+                                  haz_bin=args.haz_bin, rtol=args.rtol),
+                iter_cases(args.root_ref, args.patterns, args.all_cases))
             ok = all(results.get())
 
     sys.exit(0 if ok else 1)


### PR DESCRIPTION
Modified the Travis build to:
- only consider the fast tests from Set1 and Set2. Other sets can be included once their runtime is known. Maximum of 10 minutes on Travis is allowed.
- use local Python instead of installing conda

Modified the Python code to include:
- reporting of test durations
- support for type checking
- use `pathlib` instead of `os.path`
- incomplete support for reading fractile files
