### PR TITLE
Fixes indexing for MChar

### DIFF
--- a/HAZ files/readFlt.f
+++ b/HAZ files/readFlt.f
@@ -591,7 +591,7 @@ c                Scale moment rate by reference thickness.
                  else
                    RateParamWt(iFlt,i,iWidth) = RateWt1(iRate) * bValueWt1(i_bValue) 
                  endif
-                 maxMagWt(iFlt,i,iWidth) = refMagWt1(iThick1,iRefMag)
+                 maxMagWt(iFlt,i,iWidth) = refMagWt1(iWidth,iRefMag)
 
 c                Set max mag
                  if (magRecur1(iRecur) .eq. 0 ) then
@@ -1328,7 +1328,7 @@ c                Scale moment rate by reference thickness.
                  else
                    RateParamWt(iFlt,i,iWidth) = RateWt1(iRate) * bValueWt1(i_bValue) 
                  endif
-                 maxMagWt(iFlt,i,iWidth) = refMagWt1(iThick1,iRefMag)
+                 maxMagWt(iFlt,i,iWidth) = refMagWt1(iWidth,iRefMag)
 
 c                Set max mag
                  if (magRecur1(iRecur) .eq. 0 ) then


### PR DESCRIPTION
Fixes indexing for MChar if user used a different number of MChar for each crustal thickness for a given fault.

Attached screen captures show code tested with Tagged Haz45.2 vs. the updated version.  The error was evident with the fractiles code and so screenshots are from running SSC fractiles code.
![haz45 3develop_run](https://cloud.githubusercontent.com/assets/12616639/23592008/42ac8e20-01af-11e7-9266-4d4e094bc219.PNG)
![tagged_haz45 2](https://cloud.githubusercontent.com/assets/12616639/23592007/42ac7ab6-01af-11e7-8369-5b2aae111f0e.png)

